### PR TITLE
(maint) Initial type tests + travis configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Final publish location for module build
+pkg/
+
+# VIM files
+*.swp
+
+# Mac files
+.DS_Store
+
+# Generated directory for coverage results
+coverage/
+
+# Gem & bundler related files we do not want persisted to the repository
+Gemfile.lock
+.bundle
+vendor/
+
+# Used by rake spec, for temp modules and other test requirements
+spec/fixtures/
+
+# RVM files that are specific to developers implementation
+.ruby-version
+.ruby-gemset

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: ruby
+bundler_args: --without development
+script: "bundle exec rake spec SPEC_OPTS='--format documentation'"
+rvm:
+  - 1.9.3
+  - 2.0.0
+  - 2.1.10
+  - 2.2.5
+  - 2.3.1
+env:
+  - PUPPET_GEM_VERSION="~> 4.0"
+notifications:
+  email: false

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,9 @@ source 'https://rubygems.org'
 
 puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['>= 3.3']
 gem 'puppet', puppetversion
-gem 'puppetlabs_spec_helper', '>= 0.8.2'
-gem 'puppet-lint', '>= 1.0.0'
 gem 'facter', '>= 1.7.0'
+
+group :development, :test do
+  gem 'puppetlabs_spec_helper', '>= 0.8.2'
+  gem 'puppet-lint', '>= 1.0.0'
+end

--- a/lib/puppet/type/database.rb
+++ b/lib/puppet/type/database.rb
@@ -1,5 +1,4 @@
 Puppet::Type.newtype :database, :is_capability => true do
-
   ensurable do
     defaultvalues
     defaultto :present

--- a/lib/puppet/type/http.rb
+++ b/lib/puppet/type/http.rb
@@ -1,6 +1,17 @@
 Puppet::Type.newtype :http, :is_capability => true do
-  newparam :name, :is_namevar => true
-  newparam :ip
-  newparam :port
-  newparam :host
+  newparam(:name, :is_namevar => true) do
+    desc 'The name of the resource'
+  end
+
+  newparam(:ip) do
+    desc 'IP address of the HTTP service'
+  end
+
+  newparam(:port) do
+    desc 'Port of the HTTP service'
+  end
+
+  newparam(:host) do
+    desc 'Hostname of the HTTP service'
+  end
 end

--- a/spec/unit/type/database_spec.rb
+++ b/spec/unit/type/database_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:database) do
+  describe "generally" do
+    it "should have :name as its namevar" do
+      expect(described_class.key_attributes).to eq([:name])
+    end
+  end
+
+  describe "timeout parameter" do
+    it "should validate that values are integers" do
+      expect { described_class.new(:name => 'test', :timeout => 60) }.to_not raise_error
+    end
+
+    it "should raise error when values are not integers" do
+      expect { described_class.new(:name => 'test', :timeout => 'foo') }.to raise_error(Puppet::ResourceError, /invalid value/)
+    end
+  end
+
+  describe "ping_interval parameter" do
+    it "should validate that values are integers" do
+      expect { described_class.new(:name => 'test', :ping_interval => 60) }.to_not raise_error
+    end
+
+    it "should raise error when values are not integers" do
+      expect { described_class.new(:name => 'test', :ping_interval => 'foo') }.to raise_error(Puppet::ResourceError, /invalid value/)
+    end
+  end
+end

--- a/spec/unit/type/http_spec.rb
+++ b/spec/unit/type/http_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:http) do
+  describe "parameters" do
+    it "should have :name as its namevar" do
+      expect(described_class.key_attributes).to eq([:name])
+    end
+  end
+end


### PR DESCRIPTION
This sets up some basic tests for the database & http types and includes a basic travis
configuration for PR testing.

This also adds a very minimal .gitignore and updates the Gemfile so that test libraries
are in the test/development group.

Signed-off-by: Ken Barber ken@bob.sh
