### PR TITLE
(ORCH-1465) Add dependency only application helpers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ $lb_components.each |$comp_name| {
 
 ### Types
 
+#### `dependency`
+
+The dependency type passes no information and has no availabilty check. This is
+useful if you only care about order.
+
 #### `http`
 
 The `http` type allows the following parameters and providers:
@@ -115,3 +120,37 @@ This function searches the node hash of an application for all nodes that have a
 ```
 collect_component_nodes($nodes, Wordpress_app::Web)
 ```
+
+#### `create_node_order`
+
+This function can be used in the site block to create order only applications.
+It accepts a name for the application and a list of node layers. It creates an
+instance of app_modeling::node_order where the nodes at each layer depend on
+all the nodes in the previous layer.
+
+The following code will create a dependency between two nodes. Whenever these
+nodes are both in an orchestrator job node1 will run before node2. These nodes
+can also be targeted with `puppet job run --application
+App_modeling::Node_order['node1-node2']`.
+
+```puppet
+site {
+  create_node_order('node1-node2', ['node1.example.com', 'node2.example.com'])
+}
+```
+
+If you have a three layer web application with a database, some app_servers and
+a load balancer the following code would create an application for them. That
+application could then be deployed with orchestrator with `puppet job run
+--application App_modeling::Node_order['three_tier']`.
+
+```puppet
+site {
+  create_node_order('three_tier', ['database.example.com', ['web1.example.com','web2.example.com','web3.example.com'], 'lb.example.com'])
+}
+```
+
+##### Params
+
+* `title` - The title of the node_order application to create.
+* `nodes` - An array of node layers to order. A node layer can consist of a single node name or an array of node names.

--- a/functions/wrap_array.pp
+++ b/functions/wrap_array.pp
@@ -1,0 +1,8 @@
+function app_modeling::wrap_array (
+  $maybe_array,
+) {
+  is_array($maybe_array) ? {
+    true => $maybe_array,
+    false => [$maybe_array],
+  }
+}

--- a/lib/puppet/parser/functions/collect_component_nodes.rb
+++ b/lib/puppet/parser/functions/collect_component_nodes.rb
@@ -9,7 +9,7 @@ module Puppet::Parser::Functions
   newfunction(:collect_component_nodes, type: :rvalue) do |args|
     nodes = args[0]
     component = args [1]
-    Raise Puppet::ParseError, "collect_component_nodes requires a nodes hash and component" unless nodes && component
+    raise Puppet::ParseError, "collect_component_nodes requires a nodes hash and component" unless nodes && component
     target = component.type
     nodes.map do |node, components|
       components = [components] unless components.kind_of?(Array)

--- a/lib/puppet/parser/functions/create_node_order.rb
+++ b/lib/puppet/parser/functions/create_node_order.rb
@@ -1,0 +1,32 @@
+# Given an instance title and list of node names creates a node_order application for them
+#
+# # create_node_order('node1->node2', ['node1', 'node2']
+#
+# creates and node order where node1 runs before node2
+#
+# # create_node_order('db->web', ['database-node', ['web-node1', 'web-node2'], 'lb-node'])
+#
+# creates a node order where first the database will run followed by the web nodes and finally the lb
+#
+#
+# @param app_name String the name of the node_order application to create
+# @prams nodes [String | [String] A list of nodes or layers of nodes to order.
+module Puppet::Parser::Functions
+  newfunction(:create_node_order, arity: 2) do |args|
+    app_name, order = args
+
+    nodes = {}
+    order.flatten.each do |node_name|
+      node = Puppet::Resource.new(nil, "Node[#{node_name}]", {})
+      comp = Puppet::Resource.new(nil, "App_modeling::Dependency[#{app_name}-#{node_name}]", {})
+      # Make sure this node doesn't already appear
+      if nodes.keys.any? {|n| n.title == node.title}
+        raise Puppet::ParseError, "Cannot create node_order '#{app_name}' node '#{node_name}' is included twice"
+      end
+      nodes[node] = comp
+    end
+    #raise Puppet::ParseError, "nodes are: #{nodes}"
+    params = {app_name => { "order" => order, "nodes" => nodes}}
+    function_create_resources(["app_modeling::node_order", params])
+  end
+end

--- a/lib/puppet/provider/dependency.rb
+++ b/lib/puppet/provider/dependency.rb
@@ -1,0 +1,5 @@
+require 'puppet/provider'
+require 'puppet/provider/null_provider'
+
+#Use the null provider
+Puppet::Type.type(:dependency).provide(:dependency, parent: Puppet::Provider::NullProvider) {}

--- a/lib/puppet/provider/null_provider.rb
+++ b/lib/puppet/provider/null_provider.rb
@@ -1,0 +1,8 @@
+require 'puppet/provider'
+
+class Puppet::Provider::NullProvider < Puppet::Provider
+  # This always returns true since we don't care about availability
+  def exists?
+    return true
+  end
+end

--- a/lib/puppet/type/dependency.rb
+++ b/lib/puppet/type/dependency.rb
@@ -1,0 +1,3 @@
+Puppet::Type.newtype :dependency, is_capability: true do
+  newparam :name
+end

--- a/manifests/dependency.pp
+++ b/manifests/dependency.pp
@@ -1,0 +1,6 @@
+# This is an empty compontent to produce dependency capabilities for ordering only
+define app_modeling::dependency() {
+}
+
+App_modeling::Dependency produces Dependency {}
+App_modeling::Dependency consumes Dependency {}

--- a/manifests/node_order.pp
+++ b/manifests/node_order.pp
@@ -1,0 +1,19 @@
+# This is intended to use with the create_node_order function
+# It takes a node order which is an array of node name arrays.
+# nodes in each each array will depend on nodes in the previous array
+# Must have a component of App_modeling::Dependency["$name::$certname"]
+# assigned to each node.
+application app_modeling::node_order(
+  $order,
+) {
+  $order.reduce([]) |$deps, $current| {
+    app_modeling::wrap_array($current).map |$nod| {
+      $capre = Dependency["${name}-${nod}"]
+      app_modeling::dependency{"${name}-${nod}":
+        export  => $capre,
+        consume => $deps,
+      }
+      $capre
+    }
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -104,7 +104,12 @@
       "version_requirement": ">=4.5.0 <5.0.0"
     }
   ],
-  "dependencies": [],
+  "dependencies": [
+    {
+      "name": "puppetlabs-stdlib",
+      "version_requirement": "<5.0.0"
+    }
+   ],
   "data_provider": null
 }
 


### PR DESCRIPTION
This adds the dependency capability which can be used when ordering only
is needed.

In addition it adds a create_node_order function and
app_modeling::node_order application to allow users to set up dependency
chains for nodes in site.pp
