### PR TITLE
(ORCH-1466) Data only capability type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,26 @@ $lb_components.each |$comp_name| {
 ```
 ## Reference
 
+#### `data_capability`
+
+The data_capability type accepts a single parameter data which can be used to
+pass arbitrary data to other other nodes. There is no avilability check. See [examples/data.pp](https://github.com/puppetlabs/puppetlabs-app_modeling/blob/master/examples/data.pp)
+
+##### Parameters
+
+* `data`: Allows user to pass arbitrary data from from one component to another.
+
 ### Types
+
+#### `data_capability`
+
+This type passes information between nodes but has no availability check. It's
+useful if you need to pass data but don't care about whether services are
+actually running.
+
+##### `Parameters`
+
+* `data`: Arbitrary data to produce or consume usually this should be a hash.
 
 #### `dependency`
 

--- a/examples/data.pp
+++ b/examples/data.pp
@@ -1,0 +1,46 @@
+define data_app::producer (
+  $base_data,
+) { }
+
+
+define data_app::consumer (
+  $data,
+) {
+  notify { "Consumer passed data: ${data}": }
+}
+
+application data_app(
+  $base_data = {} )
+{
+  data_app::producer {"${name}":
+    base_data => $base_data,
+    export    => Data_capability['produced-data'],
+  }
+
+  data_app::consumer {"${name}":
+    consume => Data_capability['produced-data'],
+  }
+}
+
+site {
+
+  # In addition add the fqdn of the producer node to the data before exporting it.
+  Data_app::Producer produces Data_capability {
+    data => $base_data + { 'producer_node' => $::fqdn }
+  }
+
+  Data_app::Consumer consumes Data_capability { }
+
+  data_app {'all-in-one':
+    nodes => {
+      Node['node1.example.com'] => [Data_app::Producer['all-in-one'],
+                                    Data_app::Consumer['all-in-one'],]
+    }
+  }
+  data_app {'example':
+    nodes => {
+      Node['node1.example.com'] => Data_app::Producer['example'],
+      Node['node2.example.com'] => Data_app::Consumer['example'],
+    }
+  }
+}

--- a/lib/puppet/provider/data_capability.rb
+++ b/lib/puppet/provider/data_capability.rb
@@ -1,0 +1,3 @@
+require 'puppet/provider'
+#Use the null provider
+Puppet::Type.type(:data_capability).provide(:data_capability, parent: Puppet::Provider::NullProvider) {}

--- a/lib/puppet/type/data_capability.rb
+++ b/lib/puppet/type/data_capability.rb
@@ -1,0 +1,6 @@
+Puppet::Type.newtype :data_capability, is_capability: true do
+  newparam :name
+  newparam :data do
+    desc "the data to pass through the capability"
+  end
+end


### PR DESCRIPTION
This adds a new data_capability capability type intended to be used
for passing data between components without worrying about availability
  checks
